### PR TITLE
Add access controller for index insight visit

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/indexInsight/IndexInsightAccessControllerHelper.java
+++ b/common/src/main/java/org/opensearch/ml/common/indexInsight/IndexInsightAccessControllerHelper.java
@@ -1,0 +1,30 @@
+package org.opensearch.ml.common.indexInsight;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.transport.client.Client;
+
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class IndexInsightAccessControllerHelper {
+    // Verify the access by dry run
+    public static void verifyAccessController(Client client, ActionListener<Boolean> actionListener, String targetIndex) {
+        SearchRequest searchRequest = constructSimpleQueryRequest(targetIndex);
+        client.search(searchRequest, ActionListener.wrap(r -> { actionListener.onResponse(true); }, e -> {
+            log.error("You don't have access to this index");
+            actionListener.onFailure(new IllegalArgumentException("You don't have access to this index"));
+        }));
+    }
+
+    public static SearchRequest constructSimpleQueryRequest(String targetIndex) {
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.query(new MatchAllQueryBuilder());
+        searchSourceBuilder.size(1);
+        SearchRequest searchRequest = new SearchRequest(targetIndex);
+        searchRequest.source(searchSourceBuilder);
+        return searchRequest;
+    }
+}


### PR DESCRIPTION
### Description
Add access controller for index insight. A dry run using user's credential with a simple match_all will be triggered.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
