### PR TITLE
Filter useless column

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/indexInsight/FieldDescriptionTask.java
+++ b/common/src/main/java/org/opensearch/ml/common/indexInsight/FieldDescriptionTask.java
@@ -16,7 +16,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -196,7 +195,7 @@ public class FieldDescriptionTask implements IndexInsightTask {
                 log.error("Error parsing response for batch in index {}: {}", sourceIndex, e.getMessage());
                 listener.onFailure(e);
             }
-        }, e -> {listener.onFailure(e);}));
+        }, e -> { listener.onFailure(e); }));
     }
 
     private String generateBatchPrompt(List<String> batchFields, Map<String, Object> statisticalContentMap) {
@@ -249,7 +248,6 @@ public class FieldDescriptionTask implements IndexInsightTask {
             if (!relevantMapping.isEmpty()) {
                 result.put(IMPORTANT_COLUMN_KEYWORD, relevantMapping);
             }
-
 
             // Extract example docs from distribution
             List<Map<String, Object>> exampleDocs = (List<Map<String, Object>>) statisticalContentMap.get(EXAMPLE_DOC_KEYWORD);

--- a/common/src/main/java/org/opensearch/ml/common/indexInsight/FieldDescriptionTask.java
+++ b/common/src/main/java/org/opensearch/ml/common/indexInsight/FieldDescriptionTask.java
@@ -7,6 +7,8 @@ package org.opensearch.ml.common.indexInsight;
 
 import static org.opensearch.ml.common.indexInsight.IndexInsightUtils.callLLMWithAgent;
 import static org.opensearch.ml.common.indexInsight.IndexInsightUtils.getAgentIdToRun;
+import static org.opensearch.ml.common.indexInsight.StatisticalDataTask.EXAMPLE_DOC_KEYWORD;
+import static org.opensearch.ml.common.indexInsight.StatisticalDataTask.IMPORTANT_COLUMN_KEYWORD;
 import static org.opensearch.ml.common.utils.StringUtils.gson;
 
 import java.util.ArrayList;
@@ -85,7 +87,7 @@ public class FieldDescriptionTask implements IndexInsightTask {
         String storageIndex,
         ActionListener<IndexInsight> listener
     ) {
-        Map<String, Object> mappingSource = (Map<String, Object>) statisticalContentMap.get("mapping");
+        Map<String, Object> mappingSource = (Map<String, Object>) statisticalContentMap.get(IMPORTANT_COLUMN_KEYWORD);
 
         if (mappingSource == null || mappingSource.isEmpty()) {
             log.error("No mapping properties found for index: {}", sourceIndex);
@@ -94,8 +96,7 @@ public class FieldDescriptionTask implements IndexInsightTask {
             return;
         }
 
-        List<String> allFields = new ArrayList<>();
-        extractAllFieldNames(mappingSource, "", allFields);
+        List<String> allFields = List.of(mappingSource.keySet().toArray(new String[0]));
 
         if (allFields.isEmpty()) {
             log.warn("No fields found for index: {}", sourceIndex);
@@ -209,14 +210,11 @@ public class FieldDescriptionTask implements IndexInsightTask {
         // Filter statistical data based on current batch fields
         Map<String, Object> relevantStatisticalData = extractRelevantStatisticalData(statisticalContentMap, batchFields);
         if (!relevantStatisticalData.isEmpty()) {
-            if (relevantStatisticalData.containsKey("mapping")) {
-                prompt.append("Field Mapping:\\n").append(relevantStatisticalData.get("mapping")).append("\\n\\n");
+            if (relevantStatisticalData.containsKey(IMPORTANT_COLUMN_KEYWORD)) {
+                prompt.append("Some Field Distribution:\\n").append(relevantStatisticalData.get(IMPORTANT_COLUMN_KEYWORD)).append("\\n\\n");
             }
-            if (relevantStatisticalData.containsKey("distribution")) {
-                prompt.append("Field Distribution:\\n").append(relevantStatisticalData.get("distribution")).append("\\n\\n");
-            }
-            if (relevantStatisticalData.containsKey("example_docs")) {
-                prompt.append("Example Documents:\\n").append(relevantStatisticalData.get("example_docs")).append("\\n\\n");
+            if (relevantStatisticalData.containsKey(EXAMPLE_DOC_KEYWORD)) {
+                prompt.append("Example Documents:\\n").append(relevantStatisticalData.get(EXAMPLE_DOC_KEYWORD)).append("\\n\\n");
             }
         }
 
@@ -237,47 +235,34 @@ public class FieldDescriptionTask implements IndexInsightTask {
         }
 
         try {
-            Map<String, Object> mapping = (Map<String, Object>) statisticalContentMap.get("mapping");
-            Map<String, Object> distribution = (Map<String, Object>) statisticalContentMap.get("distribution");
+            Map<String, Object> distribution = (Map<String, Object>) statisticalContentMap.get(IMPORTANT_COLUMN_KEYWORD);
 
             // Extract relevant mapping
             Map<String, Object> relevantMapping = new LinkedHashMap<>();
             for (String field : batchFields) {
-                if (mapping != null && mapping.containsKey(field)) {
-                    relevantMapping.put(field, mapping.get(field));
+                if (distribution != null && distribution.containsKey(field)) {
+                    relevantMapping.put(field, distribution.get(field));
                 }
             }
             if (!relevantMapping.isEmpty()) {
-                result.put("mapping", relevantMapping);
+                result.put(IMPORTANT_COLUMN_KEYWORD, relevantMapping);
             }
 
-            // Extract relevant distribution
-            Map<String, Object> relevantDistribution = new LinkedHashMap<>();
-            for (String field : batchFields) {
-                if (distribution != null && distribution.containsKey(field)) {
-                    relevantDistribution.put(field, distribution.get(field));
-                }
-            }
-            if (!relevantDistribution.isEmpty()) {
-                result.put("distribution", relevantDistribution);
-            }
 
             // Extract example docs from distribution
-            if (distribution != null && distribution.containsKey("example_docs")) {
-                List<Map<String, Object>> exampleDocs = (List<Map<String, Object>>) distribution.get("example_docs");
-                if (exampleDocs != null && !exampleDocs.isEmpty()) {
-                    List<Map<String, Object>> filteredExampleDocs = new ArrayList<>();
-                    for (Map<String, Object> doc : exampleDocs) {
-                        Map<String, Object> filteredDoc = new LinkedHashMap<>();
-                        for (String field : batchFields) {
-                            if (doc.containsKey(field)) {
-                                filteredDoc.put(field, doc.get(field));
-                            }
+            List<Map<String, Object>> exampleDocs = (List<Map<String, Object>>) statisticalContentMap.get(EXAMPLE_DOC_KEYWORD);
+            if (exampleDocs != null && !exampleDocs.isEmpty()) {
+                List<Map<String, Object>> filteredExampleDocs = new ArrayList<>();
+                for (Map<String, Object> doc : exampleDocs) {
+                    Map<String, Object> filteredDoc = new LinkedHashMap<>();
+                    for (String field : batchFields) {
+                        if (doc.containsKey(field)) {
+                            filteredDoc.put(field, doc.get(field));
                         }
-                        filteredExampleDocs.add(filteredDoc);
                     }
-                    result.put("example_docs", filteredExampleDocs);
+                    filteredExampleDocs.add(filteredDoc);
                 }
+                result.put(EXAMPLE_DOC_KEYWORD, filteredExampleDocs);
             }
 
         } catch (Exception e) {

--- a/common/src/main/java/org/opensearch/ml/common/indexInsight/StatisticalDataTask.java
+++ b/common/src/main/java/org/opensearch/ml/common/indexInsight/StatisticalDataTask.java
@@ -29,8 +29,7 @@ import org.opensearch.search.aggregations.Aggregation;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.AggregatorFactories;
 import org.opensearch.search.aggregations.bucket.filter.FiltersAggregationBuilder;
-import org.opensearch.search.aggregations.bucket.filter.FiltersAggregator;
-import org.opensearch.search.aggregations.bucket.filter.InternalFilter;
+import org.opensearch.search.aggregations.bucket.filter.FiltersAggregator.KeyedFilter;
 import org.opensearch.search.aggregations.bucket.filter.InternalFilters;
 import org.opensearch.search.aggregations.bucket.sampler.InternalSampler;
 import org.opensearch.search.aggregations.bucket.sampler.SamplerAggregationBuilder;
@@ -43,7 +42,6 @@ import org.opensearch.search.aggregations.metrics.TopHitsAggregationBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.transport.client.Client;
-import org.opensearch.search.aggregations.bucket.filter.FiltersAggregator.KeyedFilter;
 
 import lombok.extern.log4j.Log4j2;
 
@@ -61,7 +59,7 @@ public class StatisticalDataTask implements IndexInsightTask {
     private static final List<String> UNIQUE_TERMS_LIST = List.of("text", "keyword", "integer", "long", "short");
     private static final List<String> MIN_MAX_LIST = List.of("integer", "long", "float", "double", "short", "date");
     private static final String NOT_NULL_KEYWORD = "not_null";
-    private static final Double THRESHOLD = 0.2;
+    private static final Double THRESHOLD = 0.01;
     private static final int SAMPLE_NUMBER = 100000;
     public static final String IMPORTANT_COLUMN_KEYWORD = "important_column_and_distribution";
     public static final String EXAMPLE_DOC_KEYWORD = "example_docs";
@@ -194,10 +192,7 @@ public class StatisticalDataTask implements IndexInsightTask {
         for (String fieldName : fields.keySet()) {
             keyedFilters.add(new KeyedFilter(fieldName + "_" + NOT_NULL_KEYWORD, QueryBuilders.existsQuery(fieldName)));
         }
-        FiltersAggregationBuilder nonNullAgg = AggregationBuilders.filters(
-                NOT_NULL_KEYWORD,
-                keyedFilters.toArray(new KeyedFilter[0])
-        );
+        FiltersAggregationBuilder nonNullAgg = AggregationBuilders.filters(NOT_NULL_KEYWORD, keyedFilters.toArray(new KeyedFilter[0]));
         subAggs.addAggregator(nonNullAgg);
 
         // Wrap everything in a Sampler aggregation
@@ -213,7 +208,11 @@ public class StatisticalDataTask implements IndexInsightTask {
         return sourceBuilder;
     }
 
-    private Map<String, Object> parseSearchResult(Map<String, String> allFieldsToType, Set<String> filteredNames, SearchResponse searchResponse) {
+    private Map<String, Object> parseSearchResult(
+        Map<String, String> allFieldsToType,
+        Set<String> filteredNames,
+        SearchResponse searchResponse
+    ) {
         Map<String, Aggregation> aggregationMap = ((InternalSampler) searchResponse.getAggregations().getAsMap().get("sample"))
             .getAggregations()
             .getAsMap();
@@ -277,12 +276,12 @@ public class StatisticalDataTask implements IndexInsightTask {
 
     private Set<String> filterColumns(Map<String, String> allFieldsToType, SearchResponse searchResponse) {
         Map<String, Aggregation> aggregationMap = ((InternalSampler) searchResponse.getAggregations().getAsMap().get("sample"))
-                .getAggregations()
-                .getAsMap();
-        long totalDocCount =  ((InternalSampler) searchResponse.getAggregations().getAsMap().get("sample")).getDocCount();
+            .getAggregations()
+            .getAsMap();
+        long totalDocCount = ((InternalSampler) searchResponse.getAggregations().getAsMap().get("sample")).getDocCount();
         Set<String> filteredNames = new HashSet<>();
         InternalFilters aggregation = (InternalFilters) aggregationMap.get(NOT_NULL_KEYWORD);
-        for (InternalFilters.InternalBucket bucket: aggregation.getBuckets()) {
+        for (InternalFilters.InternalBucket bucket : aggregation.getBuckets()) {
             String targetField = bucket.getKey();
             targetField = targetField.substring(0, targetField.length() - 1 - NOT_NULL_KEYWORD.length());
             long docCount = bucket.getDocCount();

--- a/common/src/main/java/org/opensearch/ml/common/indexInsight/StatisticalDataTask.java
+++ b/common/src/main/java/org/opensearch/ml/common/indexInsight/StatisticalDataTask.java
@@ -59,7 +59,7 @@ public class StatisticalDataTask implements IndexInsightTask {
     private static final List<String> UNIQUE_TERMS_LIST = List.of("text", "keyword", "integer", "long", "short");
     private static final List<String> MIN_MAX_LIST = List.of("integer", "long", "float", "double", "short", "date");
     private static final String NOT_NULL_KEYWORD = "not_null";
-    private static final Double THRESHOLD = 0.01;
+    private static final Double THRESHOLD = 0.001;
     private static final int SAMPLE_NUMBER = 100000;
     public static final String IMPORTANT_COLUMN_KEYWORD = "important_column_and_distribution";
     public static final String EXAMPLE_DOC_KEYWORD = "example_docs";

--- a/common/src/main/java/org/opensearch/ml/common/indexInsight/StatisticalDataTask.java
+++ b/common/src/main/java/org/opensearch/ml/common/indexInsight/StatisticalDataTask.java
@@ -11,9 +11,11 @@ import static org.opensearch.ml.common.utils.StringUtils.gson;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.opensearch.action.admin.indices.mapping.get.GetMappingsRequest;
 import org.opensearch.action.search.SearchRequest;
@@ -26,6 +28,10 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.aggregations.Aggregation;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.AggregatorFactories;
+import org.opensearch.search.aggregations.bucket.filter.FiltersAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.filter.FiltersAggregator;
+import org.opensearch.search.aggregations.bucket.filter.InternalFilter;
+import org.opensearch.search.aggregations.bucket.filter.InternalFilters;
 import org.opensearch.search.aggregations.bucket.sampler.InternalSampler;
 import org.opensearch.search.aggregations.bucket.sampler.SamplerAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
@@ -37,6 +43,7 @@ import org.opensearch.search.aggregations.metrics.TopHitsAggregationBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.transport.client.Client;
+import org.opensearch.search.aggregations.bucket.filter.FiltersAggregator.KeyedFilter;
 
 import lombok.extern.log4j.Log4j2;
 
@@ -53,6 +60,11 @@ public class StatisticalDataTask implements IndexInsightTask {
     private static final List<String> PREFIXS = List.of("unique_terms_", "unique_count_", "max_value_", "min_value_");
     private static final List<String> UNIQUE_TERMS_LIST = List.of("text", "keyword", "integer", "long", "short");
     private static final List<String> MIN_MAX_LIST = List.of("integer", "long", "float", "double", "short", "date");
+    private static final String NOT_NULL_KEYWORD = "not_null";
+    private static final Double THRESHOLD = 0.6;
+    private static final int SAMPLE_NUMBER = 100000;
+    public static final String IMPORTANT_COLUMN_KEYWORD = "important_column_and_distribution";
+    public static final String EXAMPLE_DOC_KEYWORD = "example_docs";
 
     private final String sourceIndex;
     private final Client client;
@@ -125,11 +137,9 @@ public class StatisticalDataTask implements IndexInsightTask {
 
             client.search(searchRequest, ActionListener.wrap(searchResponse -> {
                 sampleDocuments = searchResponse.getHits().getHits();
-                Map<String, Object> result = new LinkedHashMap<>();
-                result.put("mapping", allFields);
-                result.put("distribution", parseSearchResult(searchResponse));
+                Set<String> highPriorityColumns = filterColumns(fieldsToType, searchResponse);
 
-                String statisticalContent = gson.toJson(result);
+                String statisticalContent = gson.toJson(parseSearchResult(fieldsToType, highPriorityColumns, searchResponse));
                 saveResult(statisticalContent, storageIndex, listener);
             }, e -> {
                 log.error("Failed to collect statistical data for index: {}", sourceIndex, e);
@@ -176,11 +186,22 @@ public class StatisticalDataTask implements IndexInsightTask {
         }
 
         // Add top hits example_docs
-        TopHitsAggregationBuilder topHitsAgg = AggregationBuilders.topHits("example_docs").size(5);
+        TopHitsAggregationBuilder topHitsAgg = AggregationBuilders.topHits(EXAMPLE_DOC_KEYWORD).size(5);
         subAggs.addAggregator(topHitsAgg);
 
+        // Add not none count
+        List<KeyedFilter> keyedFilters = new ArrayList<>();
+        for (String fieldName : fields.keySet()) {
+            keyedFilters.add(new KeyedFilter(fieldName + "_" + NOT_NULL_KEYWORD, QueryBuilders.existsQuery(fieldName)));
+        }
+        FiltersAggregationBuilder nonNullAgg = AggregationBuilders.filters(
+                NOT_NULL_KEYWORD,
+                keyedFilters.toArray(new KeyedFilter[0])
+        );
+        subAggs.addAggregator(nonNullAgg);
+
         // Wrap everything in a Sampler aggregation
-        SamplerAggregationBuilder samplerAgg = AggregationBuilders.sampler("sample").shardSize(100000).subAggregations(subAggs);
+        SamplerAggregationBuilder samplerAgg = AggregationBuilders.sampler("sample").shardSize(SAMPLE_NUMBER).subAggregations(subAggs);
 
         // Build search source
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
@@ -192,16 +213,17 @@ public class StatisticalDataTask implements IndexInsightTask {
         return sourceBuilder;
     }
 
-    private Map<String, Object> parseSearchResult(SearchResponse searchResponse) {
+    private Map<String, Object> parseSearchResult(Map<String, String> allFieldsToType, Set<String> filteredNames, SearchResponse searchResponse) {
         Map<String, Aggregation> aggregationMap = ((InternalSampler) searchResponse.getAggregations().getAsMap().get("sample"))
             .getAggregations()
             .getAsMap();
         Map<String, Object> result = new LinkedHashMap<>();
+        Map<String, Object> finalResult = new LinkedHashMap<>();
         List<Object> exampleDocs = null;
         for (Map.Entry<String, Aggregation> entry : aggregationMap.entrySet()) {
             String key = entry.getKey();
             Aggregation aggregation = entry.getValue();
-            if (key.equals("example_docs")) {
+            if (key.equals(EXAMPLE_DOC_KEYWORD)) {
                 SearchHit[] hits = ((InternalTopHits) aggregation).getHits().getHits();
                 exampleDocs = new ArrayList<>(hits.length);
                 for (SearchHit hit : hits) {
@@ -211,6 +233,9 @@ public class StatisticalDataTask implements IndexInsightTask {
                 for (String prefix : PREFIXS) {
                     if (key.startsWith(prefix)) {
                         String targetField = key.substring(prefix.length());
+                        if (!filteredNames.contains(targetField)) {
+                            continue;
+                        }
                         String aggregationType = key.substring(0, prefix.length() - 1);
                         Map<String, Object> aggregationResult = gson.fromJson(aggregation.toString(), Map.class);
                         Object targetValue;
@@ -233,7 +258,7 @@ public class StatisticalDataTask implements IndexInsightTask {
                                     targetValue = aggResult.get("value");
                                 }
                             }
-                            result.computeIfAbsent(targetField, k -> new HashMap<>());
+                            result.computeIfAbsent(targetField, k -> new HashMap<>(Map.of("type", allFieldsToType.get(targetField))));
                             ((Map<String, Object>) result.get(targetField)).put(aggregationType, targetValue);
                             break;
                         } catch (Exception e) {
@@ -244,9 +269,28 @@ public class StatisticalDataTask implements IndexInsightTask {
             }
         }
         if (exampleDocs != null) {
-            result.put("example_docs", exampleDocs);
+            finalResult.put(EXAMPLE_DOC_KEYWORD, exampleDocs);
         }
-        return result;
+        finalResult.put(IMPORTANT_COLUMN_KEYWORD, result);
+        return finalResult;
+    }
+
+    private Set<String> filterColumns(Map<String, String> allFieldsToType, SearchResponse searchResponse) {
+        Map<String, Aggregation> aggregationMap = ((InternalSampler) searchResponse.getAggregations().getAsMap().get("sample"))
+                .getAggregations()
+                .getAsMap();
+        long totalDocCount =  ((InternalSampler) searchResponse.getAggregations().getAsMap().get("sample")).getDocCount();
+        Set<String> filteredNames = new HashSet<>();
+        InternalFilters aggregation = (InternalFilters) aggregationMap.get(NOT_NULL_KEYWORD);
+        for (InternalFilters.InternalBucket bucket: aggregation.getBuckets()) {
+            String targetField = bucket.getKey();
+            targetField = targetField.substring(0, targetField.length() - 1 - NOT_NULL_KEYWORD.length());
+            long docCount = bucket.getDocCount();
+            if (docCount > THRESHOLD * totalDocCount && allFieldsToType.containsKey(targetField)) {
+                filteredNames.add(targetField);
+            }
+        }
+        return filteredNames;
     }
 
 }

--- a/common/src/main/java/org/opensearch/ml/common/indexInsight/StatisticalDataTask.java
+++ b/common/src/main/java/org/opensearch/ml/common/indexInsight/StatisticalDataTask.java
@@ -61,7 +61,7 @@ public class StatisticalDataTask implements IndexInsightTask {
     private static final List<String> UNIQUE_TERMS_LIST = List.of("text", "keyword", "integer", "long", "short");
     private static final List<String> MIN_MAX_LIST = List.of("integer", "long", "float", "double", "short", "date");
     private static final String NOT_NULL_KEYWORD = "not_null";
-    private static final Double THRESHOLD = 0.6;
+    private static final Double THRESHOLD = 0.2;
     private static final int SAMPLE_NUMBER = 100000;
     public static final String IMPORTANT_COLUMN_KEYWORD = "important_column_and_distribution";
     public static final String EXAMPLE_DOC_KEYWORD = "example_docs";

--- a/common/src/test/java/org/opensearch/ml/common/indexInsight/FieldDescriptionTaskTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/indexInsight/FieldDescriptionTaskTests.java
@@ -85,7 +85,7 @@ public class FieldDescriptionTaskTests {
 
     @Test
     public void testBatchProcessing_LargeFieldCount() {
-        StringBuilder mappingBuilder = new StringBuilder("{\"mapping\": {");
+        StringBuilder mappingBuilder = new StringBuilder("{\"important_column_and_distribution\": {");
         for (int i = 0; i < 66; i++) {
             if (i > 0)
                 mappingBuilder.append(",");
@@ -112,7 +112,7 @@ public class FieldDescriptionTaskTests {
 
         ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(exceptionCaptor.capture());
-        assertEquals("No mapping properties found for index: test-index", exceptionCaptor.getValue().getMessage());
+        assertEquals("No data distribution found for index: test-index", exceptionCaptor.getValue().getMessage());
     }
 
     @Test
@@ -133,7 +133,7 @@ public class FieldDescriptionTaskTests {
 
     @Test
     public void testRunTask_MLExecuteFailure() {
-        String statisticalContent = "{\"mapping\": {\"field1\": {\"type\": \"text\"}}}";
+        String statisticalContent = "{\"important_column_and_distribution\": {\"field1\": {\"type\": \"text\"}}}";
 
         mockGetSuccess(client, statisticalContent);
         mockMLConfigSuccess(client);
@@ -159,7 +159,7 @@ public class FieldDescriptionTaskTests {
 
         ArgumentCaptor<IllegalStateException> exceptionCaptor = ArgumentCaptor.forClass(IllegalStateException.class);
         verify(listener).onFailure(exceptionCaptor.capture());
-        assertEquals("No mapping properties found for index: test-index", exceptionCaptor.getValue().getMessage());
+        assertEquals("No data distribution found for index: test-index", exceptionCaptor.getValue().getMessage());
     }
 
     @Test
@@ -173,39 +173,33 @@ public class FieldDescriptionTaskTests {
 
         ArgumentCaptor<IllegalStateException> exceptionCaptor = ArgumentCaptor.forClass(IllegalStateException.class);
         verify(listener).onFailure(exceptionCaptor.capture());
-        assertEquals("No mapping properties found for index: test-index", exceptionCaptor.getValue().getMessage());
+        assertEquals("No data distribution found for index: test-index", exceptionCaptor.getValue().getMessage());
     }
 
     @Test
     public void testRunTask_EmptyFieldsList() {
         String statisticalContentWithNoTypeFields = "{"
-            + "\"mapping\": {"
-            + "\"nested_object\": {"
-            + "\"properties\": {"
-            + "\"inner_object\": {\"properties\": {}}"
-            + "}"
-            + "}"
-            + "}"
-            + "}";
+            + "\"important_column_and_distribution\": {"
+            + "}}";
 
         mockGetSuccess(client, statisticalContentWithNoTypeFields);
         mockMLConfigSuccess(client);
         mockUpdateSuccess(client);
 
         task.runTask("storage-index", "tenant-id", listener);
-
         ArgumentCaptor<IndexInsight> insightCaptor = ArgumentCaptor.forClass(IndexInsight.class);
         verify(listener).onResponse(insightCaptor.capture());
 
         IndexInsight insight = insightCaptor.getValue();
         assertEquals(MLIndexInsightType.FIELD_DESCRIPTION, insight.getTaskType());
         assertEquals("", insight.getContent());
+
     }
 
     @Test
     public void testRunTask_SuccessfulFieldDescriptionGeneration() {
         String statisticalContent = "{"
-            + "\"mapping\": {"
+            + "\"important_column_and_distribution\": {"
             + "\"user_name\": {\"type\": \"text\"},"
             + "\"user_age\": {\"type\": \"integer\"}"
             + "}"

--- a/common/src/test/java/org/opensearch/ml/common/indexInsight/FieldDescriptionTaskTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/indexInsight/FieldDescriptionTaskTests.java
@@ -178,9 +178,7 @@ public class FieldDescriptionTaskTests {
 
     @Test
     public void testRunTask_EmptyFieldsList() {
-        String statisticalContentWithNoTypeFields = "{"
-            + "\"important_column_and_distribution\": {"
-            + "}}";
+        String statisticalContentWithNoTypeFields = "{" + "\"important_column_and_distribution\": {" + "}}";
 
         mockGetSuccess(client, statisticalContentWithNoTypeFields);
         mockMLConfigSuccess(client);

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetIndexInsightIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetIndexInsightIT.java
@@ -63,7 +63,7 @@ public class RestMLGetIndexInsightIT extends RestBaseAgentToolsIT {
         assertEquals(indexInsight.get("task_type"), "STATISTICAL_DATA");
         Map<String, Object> targetContent = gson
             .fromJson(
-                "{\"mapping\":{\"field1\":{\"type\":\"long\"},\"field2\":{\"type\":\"keyword\"}},\"distribution\":{\"field1\":{\"min_value\":200.0,\"unique_count\":1.0,\"unique_terms\":[200.0],\"max_value\":200.0},\"example_docs\":[{\"field1\":200,\"field2\":\"text\"}],\"field2\":{\"unique_count\":1.0,\"unique_terms\":[\"text\"]}}}",
+                    "{\"example_docs\":[{\"field1\":200,\"field2\":\"text\"}],\"important_column_and_distribution\":{\"field2\":{\"type\":\"keyword\",\"unique_count\":1.0,\"unique_terms\":[\"text\"]},\"field1\":{\"min_value\":200.0,\"type\":\"long\",\"unique_count\":1.0,\"unique_terms\":[200.0],\"max_value\":200.0}}}",
                 Map.class
             );
         assertEquals(gson.fromJson((String) indexInsight.get("content"), Map.class), targetContent);
@@ -107,7 +107,7 @@ public class RestMLGetIndexInsightIT extends RestBaseAgentToolsIT {
         assertEquals(indexInsight.get("task_type"), "STATISTICAL_DATA");
         Map<String, Object> targetContent = gson
             .fromJson(
-                "{\"mapping\":{\"field1\":{\"type\":\"long\"},\"field2\":{\"type\":\"keyword\"}},\"distribution\":{\"field1\":{\"min_value\":200.0,\"unique_count\":1.0,\"unique_terms\":[200.0],\"max_value\":200.0},\"example_docs\":[{\"field1\":200},{\"field2\":\"text\"}],\"field2\":{\"unique_count\":1.0,\"unique_terms\":[\"text\"]}}}",
+                    "{\"example_docs\":[{\"field1\":200},{\"field2\":\"text\"}],\"important_column_and_distribution\":{\"field2\":{\"type\":\"keyword\",\"unique_count\":1.0,\"unique_terms\":[\"text\"]},\"field1\":{\"min_value\":200.0,\"type\":\"long\",\"unique_count\":1.0,\"unique_terms\":[200.0],\"max_value\":200.0}}}",
                 Map.class
             );
         assertEquals(gson.fromJson((String) indexInsight.get("content"), Map.class), targetContent);

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetIndexInsightIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLGetIndexInsightIT.java
@@ -63,7 +63,7 @@ public class RestMLGetIndexInsightIT extends RestBaseAgentToolsIT {
         assertEquals(indexInsight.get("task_type"), "STATISTICAL_DATA");
         Map<String, Object> targetContent = gson
             .fromJson(
-                    "{\"example_docs\":[{\"field1\":200,\"field2\":\"text\"}],\"important_column_and_distribution\":{\"field2\":{\"type\":\"keyword\",\"unique_count\":1.0,\"unique_terms\":[\"text\"]},\"field1\":{\"min_value\":200.0,\"type\":\"long\",\"unique_count\":1.0,\"unique_terms\":[200.0],\"max_value\":200.0}}}",
+                "{\"example_docs\":[{\"field1\":200,\"field2\":\"text\"}],\"important_column_and_distribution\":{\"field2\":{\"type\":\"keyword\",\"unique_count\":1.0,\"unique_terms\":[\"text\"]},\"field1\":{\"min_value\":200.0,\"type\":\"long\",\"unique_count\":1.0,\"unique_terms\":[200.0],\"max_value\":200.0}}}",
                 Map.class
             );
         assertEquals(gson.fromJson((String) indexInsight.get("content"), Map.class), targetContent);
@@ -107,7 +107,7 @@ public class RestMLGetIndexInsightIT extends RestBaseAgentToolsIT {
         assertEquals(indexInsight.get("task_type"), "STATISTICAL_DATA");
         Map<String, Object> targetContent = gson
             .fromJson(
-                    "{\"example_docs\":[{\"field1\":200},{\"field2\":\"text\"}],\"important_column_and_distribution\":{\"field2\":{\"type\":\"keyword\",\"unique_count\":1.0,\"unique_terms\":[\"text\"]},\"field1\":{\"min_value\":200.0,\"type\":\"long\",\"unique_count\":1.0,\"unique_terms\":[200.0],\"max_value\":200.0}}}",
+                "{\"example_docs\":[{\"field1\":200},{\"field2\":\"text\"}],\"important_column_and_distribution\":{\"field2\":{\"type\":\"keyword\",\"unique_count\":1.0,\"unique_terms\":[\"text\"]},\"field1\":{\"min_value\":200.0,\"type\":\"long\",\"unique_count\":1.0,\"unique_terms\":[200.0],\"max_value\":200.0}}}",
                 Map.class
             );
         assertEquals(gson.fromJson((String) indexInsight.get("content"), Map.class), targetContent);


### PR DESCRIPTION
### Description
This PR we update the dsl, count the not null doc count for each column, then calculate the sparsity, filter some column with threshold. 
Currently we will set threshold to 0.001, only filter very sparse column

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
