### PR TITLE
Add filter by LLM

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/indexInsight/StatisticalDataTask.java
+++ b/common/src/main/java/org/opensearch/ml/common/indexInsight/StatisticalDataTask.java
@@ -271,7 +271,7 @@ public class StatisticalDataTask implements IndexInsightTask {
             callLLMWithAgent(client, agentId, prompt, tenantId, ActionListener.wrap(response -> {
                 listener.onResponse(parseLLMFilteredResult(response));
             }, e -> { listener.onResponse(new ArrayList<>()); }));
-        }, listener::onFailure));
+        }, e -> { listener.onResponse(new ArrayList<>()); }));
     }
 
     private String generateFilterColumnPrompt(Map<String, Object> parsedResult) {

--- a/common/src/main/java/org/opensearch/ml/common/indexInsight/StatisticalDataTask.java
+++ b/common/src/main/java/org/opensearch/ml/common/indexInsight/StatisticalDataTask.java
@@ -49,6 +49,8 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.transport.client.Client;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import lombok.extern.log4j.Log4j2;
 
 /**
@@ -282,7 +284,8 @@ public class StatisticalDataTask implements IndexInsightTask {
         return String.format(PROMPT_TEMPLATE, sourceIndex, gson.toJson(parsedResult));
     }
 
-    private List<Map<String, Object>> filterSampleColumns(List<Map<String, Object>> originalDocs, List<String> targetColumns) {
+    @VisibleForTesting
+    List<Map<String, Object>> filterSampleColumns(List<Map<String, Object>> originalDocs, List<String> targetColumns) {
         if (targetColumns.isEmpty()) {
             return originalDocs;
         }
@@ -293,6 +296,7 @@ public class StatisticalDataTask implements IndexInsightTask {
         return results;
     }
 
+    @VisibleForTesting
     private Map<String, Object> constructFilterMap(String prefix, Map<String, Object> currentNode, List<String> targetColumns) {
         Map<String, Object> filterResult = new HashMap<>();
         for (Map.Entry<String, Object> entry : currentNode.entrySet()) {
@@ -301,7 +305,6 @@ public class StatisticalDataTask implements IndexInsightTask {
             if (targetColumns.contains(currentKey)) {
                 filterResult.put(entry.getKey(), currentValue);
             } else if (currentValue instanceof Map) {
-                filterResult.put(entry.getKey(), new HashMap<>());
                 Map<String, Object> tmpNode = constructFilterMap(currentKey, (Map<String, Object>) currentValue, targetColumns);
                 if (!tmpNode.isEmpty()) {
                     filterResult.put(entry.getKey(), tmpNode);

--- a/common/src/main/java/org/opensearch/ml/common/indexInsight/StatisticalDataTask.java
+++ b/common/src/main/java/org/opensearch/ml/common/indexInsight/StatisticalDataTask.java
@@ -68,6 +68,7 @@ public class StatisticalDataTask implements IndexInsightTask {
     private static final List<String> MIN_MAX_LIST = List.of("integer", "long", "float", "double", "short", "date");
     private static final Double THRESHOLD = 0.001;
     private static final int SAMPLE_NUMBER = 100000;
+    private static final String PARSE_COLUMN_NAME_PATTERN = "<column_name>(.*?)</column_name>";
     private static final int FILTER_LLM_NUMBERS = 30;
     public static final String NOT_NULL_KEYWORD = "not_null";
     public static final String IMPORTANT_COLUMN_KEYWORD = "important_column_and_distribution";
@@ -336,7 +337,7 @@ public class StatisticalDataTask implements IndexInsightTask {
 
     private List<String> parseLLMFilteredResult(String LLMResponse) {
         try {
-            Pattern pattern = Pattern.compile("<column_name>(.*?)</column_name>");
+            Pattern pattern = Pattern.compile(PARSE_COLUMN_NAME_PATTERN);
             Matcher matcher = pattern.matcher(LLMResponse);
             List<String> columns = new ArrayList<>();
             while (matcher.find()) {

--- a/common/src/test/java/org/opensearch/ml/common/indexInsight/StatisticalDataTaskTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/indexInsight/StatisticalDataTaskTests.java
@@ -11,6 +11,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.opensearch.ml.common.indexInsight.IndexInsightTestHelper.mockGetSuccess;
+import static org.opensearch.ml.common.indexInsight.IndexInsightTestHelper.mockMLConfigSuccess;
+import static org.opensearch.ml.common.indexInsight.IndexInsightTestHelper.mockMLExecuteSuccess;
 import static org.opensearch.ml.common.indexInsight.IndexInsightTestHelper.mockUpdateSuccess;
 import static org.opensearch.ml.common.indexInsight.StatisticalDataTask.EXAMPLE_DOC_KEYWORD;
 import static org.opensearch.ml.common.indexInsight.StatisticalDataTask.NOT_NULL_KEYWORD;
@@ -293,6 +295,8 @@ public class StatisticalDataTaskTests {
     @Test
     public void test_parseSearchResult() throws IOException {
         Client client = setupBasicClientMocks();
+        mockMLConfigSuccess(client);
+        mockMLExecuteSuccess(client, "");
         GetMappingsResponse getMappingsResponse = setupMappingResponse();
         ActionListener<IndexInsight> listener = mock(ActionListener.class);
 

--- a/common/src/test/java/org/opensearch/ml/common/indexInsight/StatisticalDataTaskTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/indexInsight/StatisticalDataTaskTests.java
@@ -293,6 +293,23 @@ public class StatisticalDataTaskTests {
     }
 
     @Test
+    public void testFilterSamplesColumns_WithFiltersAggregation() throws Exception {
+        Client client = mock(Client.class);
+        StatisticalDataTask task = new StatisticalDataTask("test-index", client, sdkClient);
+        Map<String, Object> listOriginal = Map.of("a", List.of(Map.of("b", 5, "c", 6)));
+        List<Map<String, Object>> result = task.filterSampleColumns(List.of(listOriginal), List.of("a.b", "a.c"));
+        assertEquals(result, List.of(listOriginal));
+
+        Map<String, Object> mapOriginal = Map.of("a", Map.of("b", 5, "c", 6));
+        List<Map<String, Object>> emptyResult = task.filterSampleColumns(List.of(mapOriginal), List.of("d"));
+        assertEquals(emptyResult, List.of(Map.of()));
+
+        List<Map<String, Object>> mapResult = task.filterSampleColumns(List.of(mapOriginal), List.of("a.b"));
+        assertEquals(mapResult, List.of(Map.of("a", Map.of("b", 5))));
+
+    }
+
+    @Test
     public void test_parseSearchResult() throws IOException {
         Client client = setupBasicClientMocks();
         mockMLConfigSuccess(client);


### PR DESCRIPTION
### Description
We change the logic to filter the columns in statistical data using LLM and limit number of final columns to only 30.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
